### PR TITLE
Add mouse wheel support for brush size

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,21 @@ function App() {
     }
   }
 
+  const handleWheel = (deltaY: number) => {
+    const step = deltaY > 0 ? -5 : 5 // scroll down = smaller, scroll up = larger
+    if (canvas.tool === 'pen') {
+      const currentSlider = valueToSlider(canvas.strokeWidth, MIN_PEN_WIDTH, MAX_PEN_WIDTH)
+      const newSlider = Math.max(0, Math.min(100, currentSlider + step))
+      const newWidth = sliderToValue(newSlider, MIN_PEN_WIDTH, MAX_PEN_WIDTH)
+      canvas.setStrokeWidth(newWidth)
+    } else {
+      const currentSlider = valueToSlider(canvas.eraserWidth, MIN_ERASER_WIDTH, MAX_ERASER_WIDTH)
+      const newSlider = Math.max(0, Math.min(100, currentSlider + step))
+      const newWidth = sliderToValue(newSlider, MIN_ERASER_WIDTH, MAX_ERASER_WIDTH)
+      canvas.setEraserWidth(newWidth)
+    }
+  }
+
   const currentWidth = canvas.tool === 'eraser' ? canvas.eraserWidth : canvas.strokeWidth
   const currentColor = canvas.tool === 'eraser' ? '#ffffff' : canvas.strokeColor
 
@@ -169,6 +184,7 @@ function App() {
             onStartStroke={canvas.startStroke}
             onAddPoint={canvas.addPoint}
             onEndStroke={canvas.endStroke}
+            onWheel={handleWheel}
             strokeWidth={currentWidth}
             strokeColor={currentColor}
             isEraser={canvas.tool === 'eraser'}

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -8,6 +8,7 @@ type CanvasProps = {
   readonly onStartStroke: (point: Point) => void
   readonly onAddPoint: (point: Point) => void
   readonly onEndStroke: () => void
+  readonly onWheel?: (deltaY: number) => void
   readonly width?: number
   readonly height?: number
   readonly backgroundColor?: string
@@ -23,6 +24,7 @@ export const Canvas = ({
   onStartStroke,
   onAddPoint,
   onEndStroke,
+  onWheel,
   width = 800,
   height = 600,
   backgroundColor = '#ffffff',
@@ -152,6 +154,16 @@ export const Canvas = ({
     [onEndStroke]
   )
 
+  const handleWheel = useCallback(
+    (event: React.WheelEvent<HTMLCanvasElement>) => {
+      if (onWheel) {
+        event.preventDefault()
+        onWheel(event.deltaY)
+      }
+    },
+    [onWheel]
+  )
+
   const cursorColor = isEraser ? '#888888' : strokeColor
 
   if (fillContainer) {
@@ -169,6 +181,7 @@ export const Canvas = ({
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
+          onWheel={handleWheel}
           style={{ touchAction: 'none', cursor: 'none' }}
         />
         {mousePos && (
@@ -192,6 +205,7 @@ export const Canvas = ({
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
+        onWheel={handleWheel}
         className="rounded-lg border border-border"
         style={{ touchAction: 'none', cursor: 'none' }}
       />


### PR DESCRIPTION
## Summary
Allow changing brush size using mouse wheel with logarithmic scaling.

Closes:
- https://github.com/usapopopooon/paint/issues/6

## Changes
- Add `onWheel` prop to Canvas component
- Mouse wheel up increases brush size
- Mouse wheel down decreases brush size
- Uses existing logarithmic scale for smooth control

## Test plan
- [x] Mouse wheel changes brush size on canvas
- [x] Works for both pen and eraser tools
- [x] `npm run test:run` passes