### PR TITLE
Fix: キャンバス未ホバー時のキャンバス外からのストローク開始位置修正 (#38)

### DIFF
--- a/src/features/pointer/components/PointerInputLayer.tsx
+++ b/src/features/pointer/components/PointerInputLayer.tsx
@@ -30,7 +30,7 @@ export const PointerInputLayer = ({
   cursor,
   className,
 }: PointerInputLayerProps) => {
-  const { pointerProps, pointerPosition } = usePointerInput({
+  const { pointerProps, pointerPosition, canvasRef } = usePointerInput({
     onStart,
     onMove,
     onEnd,
@@ -39,6 +39,7 @@ export const PointerInputLayer = ({
 
   return (
     <div
+      ref={canvasRef}
       {...pointerProps}
       className={`relative ${className ?? ''}`}
       style={{ touchAction: 'none', cursor: 'none' }}

--- a/src/features/pointer/hooks/usePointerInput.ts
+++ b/src/features/pointer/hooks/usePointerInput.ts
@@ -43,6 +43,8 @@ type UsePointerInputReturn = {
   pointerPosition: { x: number; y: number } | null
   isDrawing: boolean
   activePointerType: PointerType | null
+  /** キャンバス要素のref（ウィンドウレベルのポインター追跡に必要） */
+  canvasRef: (element: HTMLElement | null) => void
 }
 
 /**
@@ -333,6 +335,11 @@ export const usePointerInput = ({
     }
   }, [])
 
+  // refコールバック: マウント時にキャンバス要素を設定
+  const canvasRef = useCallback((element: HTMLElement | null) => {
+    canvasElementRef.current = element
+  }, [])
+
   return {
     pointerProps: {
       onPointerDown: handlePointerDown,
@@ -347,5 +354,6 @@ export const usePointerInput = ({
     pointerPosition,
     isDrawing,
     activePointerType,
+    canvasRef,
   }
 }


### PR DESCRIPTION
## Summary

- 一度もキャンバス内にポインタを移動させていない状態で、キャンバス外からドラッグした際にストローク開始位置がずれる問題を修正
- `usePointerInput`に`canvasRef`コールバックを追加し、マウント時に`canvasElementRef`を設定

## Changes

- `usePointerInput.ts`: `canvasRef`コールバックを追加して戻り値に含める
- `PointerInputLayer.tsx`: `canvasRef`を`div`の`ref`に設定
- `usePointerInput.test.ts`: `canvasRef`に関するテストを追加

## Test plan

- [x] ページ読み込み後、キャンバスにポインタを移動させずにキャンバス外からドラッグしてストロークの開始位置が正しいことを確認
- [x] 既存のテストが通ることを確認
- [x] 新規テストが通ることを確認

Closes:
- https://github.com/usapopopooon/paint/issues/38