### PR TITLE
Refactor: マジックナンバーを定数・ヘルパー関数に置き換え

### DIFF
--- a/src/features/canvas/hooks/useDrawing.ts
+++ b/src/features/canvas/hooks/useDrawing.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import type { Drawable, StrokeDrawable, Point } from '@/features/drawable'
+import { hasMinimumPoints } from '@/features/drawable'
 import type { ToolConfig } from '../../tools/types'
 import { getToolBehavior } from '../../tools/domain'
 
@@ -35,7 +36,7 @@ export const useDrawing = (onDrawableComplete: (drawable: Drawable) => void) => 
   /** ストロークを終了し、完成したDrawableをコールバックに渡す */
   const endStroke = useCallback(() => {
     setCurrentStroke((prev) => {
-      if (prev && prev.points.length > 1) {
+      if (prev && hasMinimumPoints(prev.points.length)) {
         onDrawableComplete(prev)
       }
       return null

--- a/src/features/drawable/adapters/canvas/renderStroke.ts
+++ b/src/features/drawable/adapters/canvas/renderStroke.ts
@@ -1,4 +1,5 @@
 import type { StrokeDrawable } from '../../types'
+import { hasMinimumPoints } from '../../constants'
 
 type RenderingContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
 
@@ -8,7 +9,7 @@ type RenderingContext = CanvasRenderingContext2D | OffscreenCanvasRenderingConte
  * @param stroke - レンダリングするストローク描画要素
  */
 export const renderStroke = (ctx: RenderingContext, stroke: StrokeDrawable): void => {
-  if (stroke.points.length < 2) return
+  if (!hasMinimumPoints(stroke.points.length)) return
 
   const { style } = stroke
 

--- a/src/features/drawable/constants/index.ts
+++ b/src/features/drawable/constants/index.ts
@@ -1,0 +1,12 @@
+/**
+ * ストロークを描画・保存するために必要な最小ポイント数
+ * 1点のみでは線を描画できないため、2点以上必要
+ */
+export const MIN_STROKE_POINTS = 2
+
+/**
+ * ストロークが描画可能な最小ポイント数を持っているかを判定
+ * @param pointsLength - ストロークのポイント数
+ * @returns 描画可能な場合はtrue
+ */
+export const hasMinimumPoints = (pointsLength: number): boolean => pointsLength >= MIN_STROKE_POINTS

--- a/src/features/drawable/index.ts
+++ b/src/features/drawable/index.ts
@@ -1,6 +1,9 @@
 // 型
 export type { Point, DrawableId, DrawableMetadata, StrokeDrawable, Drawable } from './types'
 
+// 定数
+export { MIN_STROKE_POINTS, hasMinimumPoints } from './constants'
+
 // ドメイン（エンティティファクトリ）
 export { generateDrawableId, createStrokeDrawable } from './domain'
 

--- a/src/features/pointer/helpers/index.ts
+++ b/src/features/pointer/helpers/index.ts
@@ -1,2 +1,3 @@
 export { getPointerType } from './getPointerType'
 export { getPointerPoint } from './getPointerPoint'
+export { isPrimaryButton, isPrimaryButtonPressed } from './pointerButton'

--- a/src/features/pointer/helpers/pointerButton.ts
+++ b/src/features/pointer/helpers/pointerButton.ts
@@ -1,0 +1,18 @@
+/** プライマリボタン（左クリック）のボタン値 */
+const PRIMARY_BUTTON = 0
+
+/** プライマリボタンのビットマスク */
+const PRIMARY_BUTTON_MASK = 1
+
+/**
+ * pointerdown/pointerup時にプライマリボタンが押されたかを判定
+ * @param button - PointerEvent.button
+ */
+export const isPrimaryButton = (button: number): boolean => button === PRIMARY_BUTTON
+
+/**
+ * pointermove/pointerenter時にプライマリボタンが押されているかを判定
+ * @param buttons - PointerEvent.buttons
+ */
+export const isPrimaryButtonPressed = (buttons: number): boolean =>
+  (buttons & PRIMARY_BUTTON_MASK) !== 0

--- a/src/features/pointer/hooks/pointerState.ts
+++ b/src/features/pointer/hooks/pointerState.ts
@@ -1,3 +1,5 @@
+import { isPrimaryButton, isPrimaryButtonPressed } from '../helpers'
+
 /** ポインター移動時のコールバック型 */
 type PointerMoveCallback = (x: number, y: number, event: PointerEvent) => void
 
@@ -21,13 +23,13 @@ export const setPointerMoveCallback = (callback: PointerMoveCallback | null): vo
 // ウィンドウレベルでポインター状態を追跡
 if (typeof window !== 'undefined') {
   window.addEventListener('pointerdown', (event) => {
-    if (event.button === 0) {
+    if (isPrimaryButton(event.button)) {
       pointerState.isPrimaryPressing = true
     }
   })
 
   window.addEventListener('pointerup', (event) => {
-    if (event.button === 0) {
+    if (isPrimaryButton(event.button)) {
       pointerState.isPrimaryPressing = false
     }
   })
@@ -37,8 +39,7 @@ if (typeof window !== 'undefined') {
   })
 
   window.addEventListener('pointermove', (event) => {
-    // プライマリボタンが押されている時のみコールバック
-    if ((event.buttons & 1) !== 0) {
+    if (isPrimaryButtonPressed(event.buttons)) {
       pointerState.onPointerMove?.(event.clientX, event.clientY, event)
     }
   })

--- a/src/features/pointer/hooks/usePointerInput.ts
+++ b/src/features/pointer/hooks/usePointerInput.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { PointerPoint, PointerType } from '../types'
-import { getPointerType, getPointerPoint } from '../helpers'
+import {
+  getPointerType,
+  getPointerPoint,
+  isPrimaryButton,
+  isPrimaryButtonPressed,
+} from '../helpers'
 import { colorWheelState } from '@/features/color/hooks/colorWheelState'
 
 /** キャンバス外でのポインター位置を追跡するための型 */
@@ -106,7 +111,7 @@ export const usePointerInput = ({
       }
 
       // プライマリボタンのみ処理（左マウスボタン、タッチ、またはペン接触）
-      if (event.button !== 0) {
+      if (!isPrimaryButton(event.button)) {
         return
       }
 
@@ -241,9 +246,7 @@ export const usePointerInput = ({
         return
       }
 
-      // プライマリボタン（左クリック）が押されている場合はストロークを開始
-      // buttons: 1 = 左ボタン
-      if (event.buttons === 1) {
+      if (isPrimaryButtonPressed(event.buttons)) {
         try {
           element.setPointerCapture(event.pointerId)
         } catch {
@@ -304,8 +307,7 @@ export const usePointerInput = ({
         return
       }
 
-      // 左ボタンが押されている場合、キャンバス相対座標で位置を保存
-      if (event.buttons === 1) {
+      if (isPrimaryButtonPressed(event.buttons)) {
         const rect = canvasElementRef.current.getBoundingClientRect()
         const x = event.clientX - rect.left
         const y = event.clientY - rect.top

--- a/src/features/tools/hooks/useTool.ts
+++ b/src/features/tools/hooks/useTool.ts
@@ -4,6 +4,13 @@ import { MIN_PEN_WIDTH, MAX_PEN_WIDTH, MIN_ERASER_WIDTH, MAX_ERASER_WIDTH } from
 import { penBehavior, eraserBehavior, getToolBehavior } from '../domain'
 import { valueToSlider, sliderToValue } from '@/lib/slider'
 
+/** ホイールでブラシサイズを調整する際のスライダー値のステップ */
+const BRUSH_SIZE_SLIDER_STEP = 5
+/** スライダーの最小値 */
+const SLIDER_MIN = 0
+/** スライダーの最大値 */
+const SLIDER_MAX = 100
+
 /**
  * ツール状態の型
  */
@@ -84,10 +91,10 @@ export const useTool = () => {
    */
   const adjustBrushSize = useCallback(
     (deltaY: number) => {
-      const step = deltaY > 0 ? -5 : 5
+      const step = deltaY > 0 ? -BRUSH_SIZE_SLIDER_STEP : BRUSH_SIZE_SLIDER_STEP
       if (state.currentType === 'pen') {
         const currentSlider = valueToSlider(state.penConfig.width, MIN_PEN_WIDTH, MAX_PEN_WIDTH)
-        const newSlider = Math.max(0, Math.min(100, currentSlider + step))
+        const newSlider = Math.max(SLIDER_MIN, Math.min(SLIDER_MAX, currentSlider + step))
         const newWidth = sliderToValue(newSlider, MIN_PEN_WIDTH, MAX_PEN_WIDTH)
         setPenWidth(newWidth)
       } else {
@@ -96,7 +103,7 @@ export const useTool = () => {
           MIN_ERASER_WIDTH,
           MAX_ERASER_WIDTH
         )
-        const newSlider = Math.max(0, Math.min(100, currentSlider + step))
+        const newSlider = Math.max(SLIDER_MIN, Math.min(SLIDER_MAX, currentSlider + step))
         const newWidth = sliderToValue(newSlider, MIN_ERASER_WIDTH, MAX_ERASER_WIDTH)
         setEraserWidth(newWidth)
       }


### PR DESCRIPTION
## Summary
- ポインターボタン判定を `isPrimaryButton` / `isPrimaryButtonPressed` ヘルパー関数に抽出
- ストロークポイント数判定を `hasMinimumPoints` 関数に抽出
- ブラシサイズ調整の定数を `BRUSH_SIZE_SLIDER_STEP`, `SLIDER_MIN/MAX` として定義
- ColorWheelのマジックナンバーを `HSV_MIN/MAX`, 角度変換定数, `CLICK_PADDING` として定義
- 定数は適切なフォルダ（`constants`）に配置

## Test plan
- [x] lint, tsc, テストがすべて通ること
- [ ] ペン・消しゴムツールが正常に動作すること
- [ ] ColorWheelの操作が正常に動作すること
- [ ] キャンバスへの描画が正常に動作すること