### PR TITLE
Fix: update screenshot timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ReactとPixiJSで構築したお絵かきアプリ。
 
-![Screenshot](https://usapopopooon.github.io/paint/screenshot.png?t=1766319764)
+![Screenshot](https://usapopopooon.github.io/paint/screenshot.png?t=1767086473)
 
 ## 機能
 


### PR DESCRIPTION
## Summary
- GitHubのcamoプロキシキャッシュを無効化するためタイムスタンプを更新

## Test plan
- [x] スクリーンショットの確認