### PR TITLE
fix: スポイトツールが透明部分で黒を取得する問題を修正

### DIFF
--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -5,47 +5,13 @@ import type { CursorConfig, ToolType } from '@/features/tools/types'
 import type { CanvasOffset } from '../hooks/useCanvasOffset'
 import { DrawingCanvas } from './DrawingCanvas'
 import { PointerInputLayer } from '../../pointer'
+import { getPixelColor } from '../helpers'
 
 /**
  * スポイトツール用のカーソル（SVG data URL）
  * lucide-reactのPipetteアイコンをベースに作成
  */
 const EYEDROPPER_CURSOR = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m2 22 1-1h3l9-9'/%3E%3Cpath d='M3 21v-3l9-9'/%3E%3Cpath d='m15 6 3.4-3.4a2.1 2.1 0 1 1 3 3L18 9l.4.4a2.1 2.1 0 1 1-3 3l-3.8-3.8a2.1 2.1 0 1 1 3-3l.4.4Z'/%3E%3C/svg%3E") 0 24, crosshair`
-
-/**
- * キャンバス上の指定位置からピクセルカラーを取得
- * WebGLキャンバス（PixiJS）とCanvas2Dの両方に対応
- * @param canvas - HTMLCanvasElement
- * @param x - X座標
- * @param y - Y座標
- * @returns 色の16進数文字列 (#RRGGBB形式)
- */
-const getPixelColor = (canvas: HTMLCanvasElement, x: number, y: number): string | null => {
-  const floorX = Math.floor(x)
-  const floorY = Math.floor(y)
-
-  // WebGLコンテキストを試す
-  const gl = canvas.getContext('webgl2') || canvas.getContext('webgl')
-  if (gl) {
-    const pixel = new Uint8Array(4)
-    // WebGLはY軸が反転しているので調整
-    gl.readPixels(floorX, canvas.height - floorY - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel)
-    const r = pixel[0].toString(16).padStart(2, '0')
-    const g = pixel[1].toString(16).padStart(2, '0')
-    const b = pixel[2].toString(16).padStart(2, '0')
-    return `#${r}${g}${b}`
-  }
-
-  // 2Dコンテキストにフォールバック
-  const ctx = canvas.getContext('2d', { willReadFrequently: true })
-  if (!ctx) return null
-
-  const pixel = ctx.getImageData(floorX, floorY, 1, 1).data
-  const r = pixel[0].toString(16).padStart(2, '0')
-  const g = pixel[1].toString(16).padStart(2, '0')
-  const b = pixel[2].toString(16).padStart(2, '0')
-  return `#${r}${g}${b}`
-}
 
 /**
  * Canvasコンポーネントのプロパティ

--- a/src/features/canvas/helpers/getPixelColor.test.ts
+++ b/src/features/canvas/helpers/getPixelColor.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getPixelColor } from './getPixelColor'
+
+describe('getPixelColor', () => {
+  const createMockCanvas = (width = 100, height = 100) => {
+    return {
+      width,
+      height,
+      getContext: vi.fn(),
+    } as unknown as HTMLCanvasElement
+  }
+
+  describe('Canvas2D context', () => {
+    it('不透明なピクセルの色をHEX形式で返す', () => {
+      const canvas = createMockCanvas()
+      const mockCtx = {
+        getImageData: vi.fn().mockReturnValue({
+          data: new Uint8ClampedArray([255, 128, 64, 255]), // 不透明
+        }),
+      }
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockImplementation((type: string) => {
+        if (type === '2d') return mockCtx
+        return null
+      })
+
+      const result = getPixelColor(canvas, 10, 20)
+
+      expect(result).toBe('#ff8040')
+      expect(mockCtx.getImageData).toHaveBeenCalledWith(10, 20, 1, 1)
+    })
+
+    it('透明なピクセル（alpha=0）の場合はnullを返す', () => {
+      const canvas = createMockCanvas()
+      const mockCtx = {
+        getImageData: vi.fn().mockReturnValue({
+          data: new Uint8ClampedArray([0, 0, 0, 0]), // 完全に透明
+        }),
+      }
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockImplementation((type: string) => {
+        if (type === '2d') return mockCtx
+        return null
+      })
+
+      const result = getPixelColor(canvas, 10, 20)
+
+      expect(result).toBeNull()
+    })
+
+    it('ほぼ透明なピクセル（alpha<10）の場合はnullを返す', () => {
+      const canvas = createMockCanvas()
+      const mockCtx = {
+        getImageData: vi.fn().mockReturnValue({
+          data: new Uint8ClampedArray([100, 50, 25, 9]), // alpha=9
+        }),
+      }
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockImplementation((type: string) => {
+        if (type === '2d') return mockCtx
+        return null
+      })
+
+      const result = getPixelColor(canvas, 10, 20)
+
+      expect(result).toBeNull()
+    })
+
+    it('alpha=10のピクセルは色を返す（しきい値境界）', () => {
+      const canvas = createMockCanvas()
+      const mockCtx = {
+        getImageData: vi.fn().mockReturnValue({
+          data: new Uint8ClampedArray([100, 50, 25, 10]), // alpha=10
+        }),
+      }
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockImplementation((type: string) => {
+        if (type === '2d') return mockCtx
+        return null
+      })
+
+      const result = getPixelColor(canvas, 10, 20)
+
+      expect(result).toBe('#643219')
+    })
+
+    it('小数点座標は切り捨てられる', () => {
+      const canvas = createMockCanvas()
+      const mockCtx = {
+        getImageData: vi.fn().mockReturnValue({
+          data: new Uint8ClampedArray([255, 255, 255, 255]),
+        }),
+      }
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockImplementation((type: string) => {
+        if (type === '2d') return mockCtx
+        return null
+      })
+
+      getPixelColor(canvas, 10.7, 20.9)
+
+      expect(mockCtx.getImageData).toHaveBeenCalledWith(10, 20, 1, 1)
+    })
+
+    it('コンテキストが取得できない場合はnullを返す', () => {
+      const canvas = createMockCanvas()
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockReturnValue(null)
+
+      const result = getPixelColor(canvas, 10, 20)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('WebGL context', () => {
+    it('WebGL2コンテキストで不透明なピクセルの色を返す', () => {
+      const canvas = createMockCanvas()
+      const mockGl = {
+        RGBA: 6408,
+        UNSIGNED_BYTE: 5121,
+        readPixels: vi.fn((_x, _y, _w, _h, _format, _type, pixels: Uint8Array) => {
+          pixels[0] = 255
+          pixels[1] = 0
+          pixels[2] = 128
+          pixels[3] = 255 // 不透明
+        }),
+      }
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockImplementation((type: string) => {
+        if (type === 'webgl2') return mockGl
+        return null
+      })
+
+      const result = getPixelColor(canvas, 10, 20)
+
+      expect(result).toBe('#ff0080')
+      // WebGLはY軸が反転しているので canvas.height - y - 1
+      expect(mockGl.readPixels).toHaveBeenCalledWith(
+        10,
+        79,
+        1,
+        1,
+        6408,
+        5121,
+        expect.any(Uint8Array)
+      )
+    })
+
+    it('WebGLで透明なピクセルの場合はnullを返す', () => {
+      const canvas = createMockCanvas()
+      const mockGl = {
+        RGBA: 6408,
+        UNSIGNED_BYTE: 5121,
+        readPixels: vi.fn((_x, _y, _w, _h, _format, _type, pixels: Uint8Array) => {
+          pixels[0] = 0
+          pixels[1] = 0
+          pixels[2] = 0
+          pixels[3] = 0 // 透明
+        }),
+      }
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockImplementation((type: string) => {
+        if (type === 'webgl2') return mockGl
+        return null
+      })
+
+      const result = getPixelColor(canvas, 10, 20)
+
+      expect(result).toBeNull()
+    })
+
+    it('WebGL1にフォールバックする', () => {
+      const canvas = createMockCanvas()
+      const mockGl = {
+        RGBA: 6408,
+        UNSIGNED_BYTE: 5121,
+        readPixels: vi.fn((_x, _y, _w, _h, _format, _type, pixels: Uint8Array) => {
+          pixels[0] = 128
+          pixels[1] = 64
+          pixels[2] = 32
+          pixels[3] = 255
+        }),
+      }
+      ;(canvas.getContext as ReturnType<typeof vi.fn>).mockImplementation((type: string) => {
+        if (type === 'webgl2') return null
+        if (type === 'webgl') return mockGl
+        return null
+      })
+
+      const result = getPixelColor(canvas, 10, 20)
+
+      expect(result).toBe('#804020')
+    })
+  })
+})

--- a/src/features/canvas/helpers/getPixelColor.ts
+++ b/src/features/canvas/helpers/getPixelColor.ts
@@ -1,0 +1,49 @@
+/** 透明とみなすアルファ値のしきい値 */
+const TRANSPARENT_THRESHOLD = 10
+
+/**
+ * キャンバス上の指定位置からピクセルカラーを取得
+ * WebGLキャンバス（PixiJS）とCanvas2Dの両方に対応
+ * @param canvas - HTMLCanvasElement
+ * @param x - X座標
+ * @param y - Y座標
+ * @returns HEX形式の色文字列 (例: #ff0000)、透明または取得できない場合はnull
+ */
+export const getPixelColor = (canvas: HTMLCanvasElement, x: number, y: number): string | null => {
+  const floorX = Math.floor(x)
+  const floorY = Math.floor(y)
+
+  // WebGLコンテキストを試す
+  const gl = canvas.getContext('webgl2') || canvas.getContext('webgl')
+  if (gl) {
+    const pixel = new Uint8Array(4)
+    // WebGLはY軸が反転しているので調整
+    gl.readPixels(floorX, canvas.height - floorY - 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel)
+
+    // 透明なピクセルはnullを返す
+    if (pixel[3] < TRANSPARENT_THRESHOLD) {
+      return null
+    }
+
+    const r = pixel[0].toString(16).padStart(2, '0')
+    const g = pixel[1].toString(16).padStart(2, '0')
+    const b = pixel[2].toString(16).padStart(2, '0')
+    return `#${r}${g}${b}`
+  }
+
+  // 2Dコンテキストにフォールバック
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })
+  if (!ctx) return null
+
+  const pixel = ctx.getImageData(floorX, floorY, 1, 1).data
+
+  // 透明なピクセルはnullを返す
+  if (pixel[3] < TRANSPARENT_THRESHOLD) {
+    return null
+  }
+
+  const r = pixel[0].toString(16).padStart(2, '0')
+  const g = pixel[1].toString(16).padStart(2, '0')
+  const b = pixel[2].toString(16).padStart(2, '0')
+  return `#${r}${g}${b}`
+}

--- a/src/features/canvas/helpers/index.ts
+++ b/src/features/canvas/helpers/index.ts
@@ -1,0 +1,1 @@
+export { getPixelColor } from './getPixelColor'


### PR DESCRIPTION
## Summary
- スポイトツールで透明なピクセルをクリックすると黒色(#000000)が取得される問題を修正
- `getPixelColor`にアルファ値チェックを追加（alpha < 10 で透明と判定）
- 関数を`helpers/`ディレクトリに移動しユニットテストを追加

Closes:
- https://github.com/usapopopooon/paint/issues/69

## Test plan
- [x] 透明部分をクリックしても色が変更されないことを確認
- [x] 不透明な部分は正常に色を取得できることを確認
- [x] ユニットテスト追加・全テストパス