### PR TITLE
fix: StorybookビルドでVitePWAプラグインを除外し、test:fullコマンドを追加

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -20,8 +20,23 @@ const config: StorybookConfig = {
     disableTelemetry: true,
   },
   viteFinal: async (config) => {
+    // StorybookビルドではVitePWAプラグインを除外（workboxがStorybookの大きなファイルをキャッシュしようとしてエラーになるため）
+    const pwaPluginNames = [
+      'vite-plugin-pwa',
+      'vite-plugin-pwa:build',
+      'vite-plugin-pwa:dev-sw',
+      'vite-plugin-pwa:info',
+    ]
+    const plugins = config.plugins?.flat().filter((plugin) => {
+      if (plugin && typeof plugin === 'object' && 'name' in plugin) {
+        return !pwaPluginNames.includes(plugin.name as string)
+      }
+      return true
+    })
+
     return {
       ...config,
+      plugins,
       base: process.env.NODE_ENV === 'production' ? '/paint/storybook/' : '/',
       optimizeDeps: {
         ...config.optimizeDeps,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:coverage:merge": "npx tsx scripts/merge-coverage.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "test:full": "tsc -b && npm run lint && npm run format:check && npm run spell:check && npm run build && npm run build-storybook",
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- StorybookビルドでVitePWAプラグインを除外（workboxがStorybookの大きなファイルをキャッシュしようとしてエラーになる問題を修正）
- `npm run test:full`コマンドを追加（tsc, lint, format, spell, build, build-storybookを一括実行）

## Test plan
- [x] `npm run build-storybook` が成功することを確認
- [x] `npm run test:full` が成功することを確認