### PR TITLE
fix: use correct base path for screenshot script

### DIFF
--- a/scripts/screenshot.ts
+++ b/scripts/screenshot.ts
@@ -9,8 +9,8 @@ const takeScreenshot = async () => {
     colorScheme: 'dark',
   })
 
-  // ビルド済みのアプリを開く
-  await page.goto('http://localhost:4173')
+  // ビルド済みのアプリを開く（GitHub Pages用のベースパスを考慮）
+  await page.goto('http://localhost:4173/paint/')
 
   // ページが完全に読み込まれるまで待機
   await page.waitForLoadState('networkidle')


### PR DESCRIPTION
## Summary

- スクリーンショットスクリプトのURLを `/paint/` ベースパスに修正
- GitHub Pages用のビルドでは `http://localhost:4173/paint/` が正しいパス

## Test plan

- [x] CIでスクリーンショットが正常に撮影されることを確認