### PR TITLE
fix: correct version badge from 0.2.4-fix to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [English](docs/README.en.md)
 
-[![version](https://img.shields.io/badge/version-0.2.4-fix-blue)](https://github.com/usapopopooon/paint/releases/tag/v0.3.0-fix) [![CI](https://github.com/usapopopooon/paint/actions/workflows/ci.yml/badge.svg)](https://github.com/usapopopooon/paint/actions/workflows/ci.yml) ![coverage](https://usapopopooon.github.io/paint/coverage-badge.svg) [![Demo](https://img.shields.io/badge/Demo-open-green?logo=github-pages)](https://usapopopooon.github.io/paint/) [![Storybook](https://img.shields.io/badge/Storybook-open-ff4785?logo=storybook&logoColor=white)](https://usapopopooon.github.io/paint/storybook/)
+[![version](https://img.shields.io/badge/version-0.3.0-blue)](https://github.com/usapopopooon/paint/releases/tag/v0.3.0) [![CI](https://github.com/usapopopooon/paint/actions/workflows/ci.yml/badge.svg)](https://github.com/usapopopooon/paint/actions/workflows/ci.yml) ![coverage](https://usapopopooon.github.io/paint/coverage-badge.svg) [![Demo](https://img.shields.io/badge/Demo-open-green?logo=github-pages)](https://usapopopooon.github.io/paint/) [![Storybook](https://img.shields.io/badge/Storybook-open-ff4785?logo=storybook&logoColor=white)](https://usapopopooon.github.io/paint/storybook/)
 
 ReactとCanvas 2Dで構築したお絵かきアプリ 👉 [実際に触ってみる](https://usapopopooon.github.io/paint/)
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -4,7 +4,7 @@
 
 [日本語](../README.md)
 
-[![version](https://img.shields.io/badge/version-0.2.4-fix-blue)](https://github.com/usapopopooon/paint/releases/tag/v0.3.0-fix) [![CI](https://github.com/usapopopooon/paint/actions/workflows/ci.yml/badge.svg)](https://github.com/usapopopooon/paint/actions/workflows/ci.yml) ![coverage](https://usapopopooon.github.io/paint/coverage-badge.svg) [![Demo](https://img.shields.io/badge/Demo-open-green?logo=github-pages)](https://usapopopooon.github.io/paint/) [![Storybook](https://img.shields.io/badge/Storybook-open-ff4785?logo=storybook&logoColor=white)](https://usapopopooon.github.io/paint/storybook/)
+[![version](https://img.shields.io/badge/version-0.3.0-blue)](https://github.com/usapopopooon/paint/releases/tag/v0.3.0) [![CI](https://github.com/usapopopooon/paint/actions/workflows/ci.yml/badge.svg)](https://github.com/usapopopooon/paint/actions/workflows/ci.yml) ![coverage](https://usapopopooon.github.io/paint/coverage-badge.svg) [![Demo](https://img.shields.io/badge/Demo-open-green?logo=github-pages)](https://usapopopooon.github.io/paint/) [![Storybook](https://img.shields.io/badge/Storybook-open-ff4785?logo=storybook&logoColor=white)](https://usapopopooon.github.io/paint/storybook/)
 
 A drawing app built with React and Canvas 2D 👉 [Try it out](https://usapopopooon.github.io/paint/)
 


### PR DESCRIPTION
## Summary
- バージョンバッジを `0.2.4-fix` から `0.3.0` に修正
- リリースタグリンクを `v0.3.0-fix` から `v0.3.0` に修正
- README.md と docs/README.en.md の両方を更新